### PR TITLE
カレンダープログラム作成

### DIFF
--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -43,15 +43,15 @@ opt.on('-m [v]') {|v| option[:m] = v}
 opt.parse!(ARGV)
 
 # コマンドラインで入力された年月の数値化
-year_num = option[:y].to_i
-month_num = option[:m].to_i
+year_input = option[:y].to_i
+month_input = option[:m].to_i
 # コマンドラインの入力がなかった時に現在の日にちをあてる
 today = Date.today
 # 入力値を使いdateを取得する
-if year_num > 0 
-  run_date = Date.new(year = year_num , month = today.month)
-elsif month_num > 0
-  run_date = Date.new(year = today.year, month = month_num)
+if year_input > 0 
+  run_date = Date.new(year_input , today.month)
+elsif month_input > 0
+  run_date = Date.new(today.year, month_input)
 else
   run_date = today
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,6 +2,42 @@
 require 'date'
 require 'optparse'
 
+# 指定した年月を文字列で表現
+def year_month_str(run_date)
+  # year_output = run_date.year.to_s
+  # month_output = run_date.month.to_s
+  output_string = run_date.month.to_s + "月" + "\s" + run_date.year.to_s
+end
+p year_month_str
+# 曜日を文字列として表現
+def weeks_str
+  "\s日\s月\s火\s水\s木\s金\s土"
+end
+p weeks_str
+# #指定した年月の日数の取得
+# def month_days(run_date)
+#   first_day = Date.new(@run_today.year, @run_today.month, 1)
+#   last_day = Date.new(run_date.year, run_date.month, -1)
+
+#   output_string = ""
+#   output_string += year_month_str.center(21) + "\n"
+#   output_string += weeks_str + "\n"
+  
+#   # #月頭の空白処理
+#   output_string += "".rjust(3) * first_day.wday
+
+#   # #取得した日数の月ごとの正規化
+#   # #日数の繰り返し
+#   (1..last_day).each do |day|
+#     if day.wday == 6
+#       output_string += day.day.to_s.rjust(3) + "\n"
+#     else
+#       output_string += day.day.to_s.rjust(3)
+#     end
+#   end
+#   output_string
+# end
+
 opt = OptionParser.new
 option = {}
 
@@ -10,56 +46,19 @@ opt.on('-m [v]') {|v| option[:m] = v}
 
 opt.parse!(ARGV)
 
-year = option[:y].to_i
-month = option[:m].to_i
-
+# コマンドラインで入力された年月の数値化
+year_num = option[:y].to_i
+month_num = option[:m].to_i
+# コマンドラインの入力がなかった時に現在の日にちをあてる
 today = Date.today
-
-if year > 0 && month > 0
-  @run_today = Date.new(year, month)
-elsif year > 0
-  @run_today = Date.new(year = year, mon = today.month)
-elsif month > 0
-  @run_today = Date.new(year = today.year, mon = month)
+# 入力値を使いdateを取得する
+if year_num > 0 
+  run_date = Date.new(year = year_num , month = today.month)
+elsif month_num > 0
+  run_date = Date.new(year = today.year, month = month_num)
 else
-  @run_today = Date.today
+  run_date = today
 end
-
-#指定した年月を取得
-def year_date
-  year_name = @run_today.year.to_s
-  month_name = @run_today.month.to_s
-  output_string = month_name + "月" + "\s" + year_name
-end
-
-#曜日の取得
-def weeks_name
-  "\s日\s月\s火\s水\s木\s金\s土"
-end
-
-#指定した年月の日数の取得
-def month_days
-  first_day = Date.new(@run_today.year, @run_today.month, 1)
-  last_day = Date.new(@run_today.year, @run_today.month, -1)
-
-  output_string = ""
-  output_string += year_date.center(21) + "\n"
-  output_string += weeks_name + "\n"
-  
-  # #月頭の空白処理
-  output_string += "".rjust(3) * first_day.wday
-
-  # #取得した日数の月ごとの正規化
-  # #日数の繰り返し
-  (first_day..last_day).each do |day|
-    if day.wday == 6
-      output_string += day.day.to_s.rjust(3) + "\n"
-    else
-      output_string += day.day.to_s.rjust(3)
-    end
-  end
-  output_string
-end
-
+p run_date
 # 正規化した日数の表示
-puts month_days
+# puts month_days

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,27 +2,25 @@
 require 'date'
 require 'optparse'
 
-def output_year_month_day_of_week_str(subject_date)
+def output_year_month_week_str(subject_data)
   # 年月を文字列
-  year_month = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
+  year_month = subject_data.month.to_s + '月' + "\s" + subject_data.year.to_s
   # 曜日の文字列
   weeks = "\s日\s月\s火\s水\s木\s金\s土"
   puts year_month.center(25) + "\n" + weeks.center(1)
 end
 
 # 指定した年月の日数データを週ごとに表示
-def output_numdays_of_specified_year_month_foreach_week(insert_date)
+def output_numdays_of_day(insert_data)
   # 指定した年月の最終日を文字列で取得
-  last_day = Date.new(insert_date.year, insert_date.month, -1)
+  last_day = Date.new(insert_data.year, insert_data.month, -1)
   # 月頭の空白処理
-  output_string = ''.rjust(3) * insert_date.wday
+  output_string = ''.rjust(3) * insert_data.wday
   # 取得した日数を1週間ごとに繰り返し
   (1..last_day.day).each do |day|
     output_string += day.to_s.rjust(3)
     # 空白の個数と変数dayを足した数が7倍数であることを判断する
-    if (insert_date.wday + day) % 7 == 0
-      output_string += "\n"
-    end
+    output_string += "\n" if (insert_data.wday + day) % 7 == 0
   end
   puts output_string
 end
@@ -30,8 +28,8 @@ end
 opt = OptionParser.new
 option = {}
 
-opt.on('-y [v]') {|v| option[:y] = v}
-opt.on('-m [v]') {|v| option[:m] = v}
+opt.on('-y [v]') { |v| option[:y] = v }
+opt.on('-m [v]') { |v| option[:m] = v }
 
 opt.parse!(ARGV)
 
@@ -47,7 +45,7 @@ else
   year = year_input
   month = month_input
 end
-run_date = Date.new(year, month)
+run_data = Date.new(year, month)
 
-output_year_month_day_of_week_str(run_date)
-output_numdays_of_specified_year_month_foreach_week(run_date)
+output_year_month_week_str(run_data)
+output_numdays_of_day(run_data)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -5,9 +5,9 @@ require 'date'
 require 'optparse'
 
 def output_year_month_week(subject_data)
-  year_month = subject_data.month.to_s + '月' + "\s" + subject_data.year.to_s
+  year_month = "#{subject_data.month}月 #{subject_data.year}"
   weeks = "\s日\s月\s火\s水\s木\s金\s土"
-  puts year_month.center(20) + "\n" + weeks.center(1)
+  puts "#{year_month.center(20)}\n#{weeks.center(1)}"
 end
 
 # 指定した年月の日数データを週ごとに表示

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -10,17 +10,17 @@ opt.on('-m [v]') {|v| option[:m] = v}
 
 opt.parse!(ARGV)
 
-year_num = option[:y].to_i
-month_num = option[:m].to_i
+year = option[:y].to_i
+month = option[:m].to_i
 
 today = Date.today
 
-if year_num > 0 && month_num > 0
-  @run_today = Date.new(year_num, month_num)
-elsif year_num > 0
-  @run_today = Date.new(year = year_num, mon = today.month)
-elsif month_num > 0
-  @run_today = Date.new(year = today.year, mon = month_num)
+if year > 0 && month > 0
+  @run_today = Date.new(year, month)
+elsif year > 0
+  @run_today = Date.new(year = year, mon = today.month)
+elsif month > 0
+  @run_today = Date.new(year = today.year, mon = month)
 else
   @run_today = Date.today
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,16 +2,14 @@
 require 'date'
 require 'optparse'
 
-def output_year_month_week_str(subject_data)
-  # 年月を文字列
+def output_year_month_week(subject_data)
   year_month = subject_data.month.to_s + '月' + "\s" + subject_data.year.to_s
-  # 曜日の文字列
   weeks = "\s日\s月\s火\s水\s木\s金\s土"
-  puts year_month.center(25) + "\n" + weeks.center(1)
+  puts year_month.center(20) + "\n" + weeks.center(1)
 end
 
 # 指定した年月の日数データを週ごとに表示
-def output_numdays_of_day(insert_data)
+def output_weeks_day(insert_data)
   # 指定した年月の最終日を文字列で取得
   last_day = Date.new(insert_data.year, insert_data.month, -1)
   # 月頭の空白処理
@@ -38,14 +36,11 @@ year_input = option[:y].to_i
 month_input = option[:m].to_i
 # コマンドラインの入力値がない時は現在の日にちをあてる
 # コマンドラインの入力値を使いdateを取得する
-if option == {}
-  year = Date.today.year
-  month = Date.today.month
-else
-  year = year_input
-  month = month_input
-end
+
+option[:y] == nil ? year = Date.today.year : year = year_input
+option[:m] == nil ? month = Date.today.month : month = month_input
+
 run_data = Date.new(year, month)
 
-output_year_month_week_str(run_data)
-output_numdays_of_day(run_data)
+output_year_month_week(run_data)
+output_weeks_day(run_data)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -21,7 +21,7 @@ def output_weeks_day(insert_data)
   (1..last_day.day).each do |day|
     output_string += day.to_s.rjust(3)
     # 空白の個数と変数dayを足した数が7倍数であることを判断する
-    output_string += "\n" if (insert_data.wday + day) % 7 == 0
+    output_string += "\n" if ((insert_data.wday + day) % 7).zero?
   end
   puts output_string
 end
@@ -39,8 +39,8 @@ year_input = option[:y].to_i
 month_input = option[:m].to_i
 # コマンドラインの入力値がない時は現在の日にちをあてる
 # コマンドラインの入力値を使いdateを取得する
-year = option[:y] == nil ? Date.today.year : year_input
-month = option[:m] == nil ? Date.today.month : month_input
+year = option[:y] == nil? ? Date.today.year : year_input
+month = option[:m] == nil? ? Date.today.month : month_input
 
 run_data = Date.new(year, month)
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -39,8 +39,8 @@ year_input = option[:y].to_i
 month_input = option[:m].to_i
 # コマンドラインの入力値がない時は現在の日にちをあてる
 # コマンドラインの入力値を使いdateを取得する
-year = option[:y] == nil? ? Date.today.year : year_input
-month = option[:m] == nil? ? Date.today.month : month_input
+year = option[:y].nil? ? Date.today.year : year_input
+month = option[:m].nil? ? Date.today.month : month_input
 
 run_data = Date.new(year, month)
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -48,14 +48,18 @@ month_input = option[:m].to_i
 # コマンドラインの入力がなかった時に現在の日にちをあてる
 today = Date.today
 # 入力値を使いdateを取得する
-if year_input > 0 
-  run_date = Date.new(year_input , today.month)
-elsif month_input > 0
-  run_date = Date.new(today.year, month_input)
-else
-  run_date = today
+year = Date.today.year
+month = Date.today.month
+if year_input > 0
+  year = year_input
 end
+if month_input > 0
+  month = month_input
+end
+run_date = Date.new(year, month)
+
 p run_date
 p year_month_str(run_date)
+
 # 正規化した日数の表示
 # puts month_days(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require 'date'
-
 require 'optparse'
 
 def output_year_month_week(subject_data)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -4,35 +4,35 @@ require 'optparse'
 
 # 指定した年月を文字列で表現
 def year_month_str(subject_date)
-  output_string = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
+  str_year_month = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
 end
 # 曜日を文字列として表現
 def weeks_str
   "\s日\s月\s火\s水\s木\s金\s土"
 end
-# # 指定した年月の日数の取得
-# def month_days(get_date)
-#   # first_day = Date.new(get_date.year, get_date.month, 1)
-#   last_day = Date.new(get_date.year, get_date.month, -1)
-
-#   output_string = ""
-#   output_string += year_month_str.center(21) + "\n"
-#   output_string += weeks_str + "\n"
+# 指定した年月の日数の取得
+def month_days(get_date)
+  # 指定した年月の最終日を文字列で取得
+  last_day_str = Date.new(get_date.year, get_date.month, -1)
+  # last_day_strを使って最終日を取得
+  end_day = last_day_str.day
+  # 月頭の空白処理
+  output_string = ""
+  output_string += "".rjust(3) * get_date.wday
+  # output_string += year_month_str.center(21) + "\n"
+  # output_string += weeks_str + "\n"
   
-#   # 月頭の空白処理
-#   output_string += "".rjust(3) * first_day.wday
-
-#   # 取得した日数の月ごとの正規化
-#   # 日数の繰り返し
-#   (1..last_day).each do |day|
-#     if day.wday == 6
-#       output_string += day.day.to_s.rjust(3) + "\n"
-#     else
-#       output_string += day.day.to_s.rjust(3)
-#     end
-#   end
-#   output_string
-# end
+  # 取得した日数の月ごとの正規化
+  # 日数の繰り返し
+  (1..end_day).each do |day|
+    if day.wday == 6
+      output_string += day.day.to_s.rjust(3) + "\n"
+    # else
+    #   output_string += day.day.to_s.rjust(3)
+    end
+  end
+  output_string
+end
 
 opt = OptionParser.new
 option = {}
@@ -59,7 +59,8 @@ end
 run_date = Date.new(year, month)
 
 p run_date
-p year_month_str(run_date)
 
+# 年月の文字列の表示
+puts year_month_str(run_date).center(21) + "\n"
 # 正規化した日数の表示
-# puts month_days(run_date)
+puts month_days(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,15 +1,20 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'date'
+
 require 'optparse'
 
-def output_year_month_week(subject_data)
+def output_year_month_week_str(subject_data)
+  # 年月を文字列
   year_month = subject_data.month.to_s + '月' + "\s" + subject_data.year.to_s
+  # 曜日の文字列
   weeks = "\s日\s月\s火\s水\s木\s金\s土"
-  puts year_month.center(20) + "\n" + weeks.center(1)
+  puts year_month.center(25) + "\n" + weeks.center(1)
 end
 
 # 指定した年月の日数データを週ごとに表示
-def output_weeks_day(insert_data)
+def output_numdays_of_day(insert_data)
   # 指定した年月の最終日を文字列で取得
   last_day = Date.new(insert_data.year, insert_data.month, -1)
   # 月頭の空白処理
@@ -36,11 +41,14 @@ year_input = option[:y].to_i
 month_input = option[:m].to_i
 # コマンドラインの入力値がない時は現在の日にちをあてる
 # コマンドラインの入力値を使いdateを取得する
-
-option[:y] == nil ? year = Date.today.year : year = year_input
-option[:m] == nil ? month = Date.today.month : month = month_input
-
+if option == {}
+  year = Date.today.year
+  month = Date.today.month
+else
+  year = year_input
+  month = month_input
+end
 run_data = Date.new(year, month)
 
-output_year_month_week(run_data)
-output_weeks_day(run_data)
+output_year_month_week_str(run_data)
+output_numdays_of_day(run_data)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,36 +2,34 @@
 require 'date'
 require 'optparse'
 
-# 指定した年月を文字列で表現
-def year_month_str(subject_date)
+# 指定した年月と曜日の文字列を文字列で表現
+def year_month_week_str(subject_date)
+  # 年月を文字列
   str_year_month = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
+  # 曜日の文字列
+  week_str = "\s日\s月\s火\s水\s木\s金\s土"
+  puts str_year_month.center(25) + "\n" + week_str.center(1)
 end
-# 曜日を文字列として表現
-def weeks_str
-  "\s日\s月\s火\s水\s木\s金\s土"
-end
+
 # 指定した年月の日数の取得
-def month_days(get_date)
+def month_days(insert_date)
   # 指定した年月の最終日を文字列で取得
-  last_day_str = Date.new(get_date.year, get_date.month, -1)
+  last_day_str = Date.new(insert_date.year, insert_date.month, -1)
   # last_day_strを使って最終日を取得
   end_day = last_day_str.day
   # 月頭の空白処理
-  output_string = ""
-  output_string += "".rjust(3) * get_date.wday
-  # output_string += year_month_str.center(21) + "\n"
-  # output_string += weeks_str + "\n"
-  
+  output_string = ''
+  output_string += ''.rjust(3) * insert_date.wday
   # 取得した日数の月ごとの正規化
   # 日数の繰り返し
   (1..end_day).each do |day|
-    if day.wday == 6
-      output_string += day.day.to_s.rjust(3) + "\n"
-    # else
-    #   output_string += day.day.to_s.rjust(3)
+    output_string += day.to_s.rjust(3)
+    # 空白の個数と変数dayを足した数が7倍数であることを判断する
+    if (insert_date.wday + day) % 7 == 0
+      output_string += "\n"
     end
   end
-  output_string
+  puts output_string
 end
 
 opt = OptionParser.new
@@ -58,9 +56,7 @@ if month_input > 0
 end
 run_date = Date.new(year, month)
 
-p run_date
-
 # 年月の文字列の表示
-puts year_month_str(run_date).center(21) + "\n"
+year_month_week_str(run_date)
 # 正規化した日数の表示
-puts month_days(run_date)
+month_days(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,7 +2,6 @@
 require 'date'
 require 'optparse'
 
-# 指定した年月と曜日の文字列を文字列で表現
 def year_month_week_str(subject_date)
   # 年月を文字列
   year_month_str = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,26 +2,22 @@
 require 'date'
 require 'optparse'
 
-def year_month_week_str(subject_date)
+def output_year_month_day_of_week_str(subject_date)
   # 年月を文字列
-  year_month_str = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
+  year_month = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
   # 曜日の文字列
-  week_str = "\s日\s月\s火\s水\s木\s金\s土"
-  puts year_month_str.center(25) + "\n" + week_str.center(1)
+  weeks = "\s日\s月\s火\s水\s木\s金\s土"
+  puts year_month.center(25) + "\n" + weeks.center(1)
 end
 
 # 指定した年月の日数データを週ごとに表示
-def weekly_date(insert_date)
+def output_numdays_of_specified_year_month_foreach_week(insert_date)
   # 指定した年月の最終日を文字列で取得
-  last_day_str = Date.new(insert_date.year, insert_date.month, -1)
-  # last_day_strを使って最終日を取得
-  end_day = last_day_str.day
+  last_day = Date.new(insert_date.year, insert_date.month, -1)
   # 月頭の空白処理
-  output_string = ''
-  output_string += ''.rjust(3) * insert_date.wday
-  # 取得した日数の月ごとの正規化
-  # 日数の繰り返し
-  (1..end_day).each do |day|
+  output_string = ''.rjust(3) * insert_date.wday
+  # 取得した日数を1週間ごとに繰り返し
+  (1..last_day.day).each do |day|
     output_string += day.to_s.rjust(3)
     # 空白の個数と変数dayを足した数が7倍数であることを判断する
     if (insert_date.wday + day) % 7 == 0
@@ -42,20 +38,16 @@ opt.parse!(ARGV)
 # コマンドラインで入力された年月の数値化
 year_input = option[:y].to_i
 month_input = option[:m].to_i
-# コマンドラインの入力がなかった時に現在の日にちをあてる
-today = Date.today
-# 入力値を使いdateを取得する
-year = Date.today.year
-month = Date.today.month
-if year_input > 0
+# コマンドラインの入力値がない時は現在の日にちをあてる
+# コマンドラインの入力値を使いdateを取得する
+if option == {}
+  year = Date.today.year
+  month = Date.today.month
+else
   year = year_input
-end
-if month_input > 0
   month = month_input
 end
 run_date = Date.new(year, month)
 
-# 年月の文字列の表示
-year_month_week_str(run_date)
-# 正規化した日数の表示
-weekly_date(run_date)
+output_year_month_day_of_week_str(run_date)
+output_numdays_of_specified_year_month_foreach_week(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -5,16 +5,14 @@ require 'date'
 
 require 'optparse'
 
-def output_year_month_week_str(subject_data)
-  # 年月を文字列
+def output_year_month_week(subject_data)
   year_month = subject_data.month.to_s + '月' + "\s" + subject_data.year.to_s
-  # 曜日の文字列
   weeks = "\s日\s月\s火\s水\s木\s金\s土"
-  puts year_month.center(25) + "\n" + weeks.center(1)
+  puts year_month.center(20) + "\n" + weeks.center(1)
 end
 
 # 指定した年月の日数データを週ごとに表示
-def output_numdays_of_day(insert_data)
+def output_weeks_day(insert_data)
   # 指定した年月の最終日を文字列で取得
   last_day = Date.new(insert_data.year, insert_data.month, -1)
   # 月頭の空白処理
@@ -41,14 +39,10 @@ year_input = option[:y].to_i
 month_input = option[:m].to_i
 # コマンドラインの入力値がない時は現在の日にちをあてる
 # コマンドラインの入力値を使いdateを取得する
-if option == {}
-  year = Date.today.year
-  month = Date.today.month
-else
-  year = year_input
-  month = month_input
-end
+year = option[:y] == nil ? Date.today.year : year_input
+month = option[:m] == nil ? Date.today.month : month_input
+
 run_data = Date.new(year, month)
 
-output_year_month_week_str(run_data)
-output_numdays_of_day(run_data)
+output_year_month_week(run_data)
+output_weeks_day(run_data)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -5,14 +5,14 @@ require 'optparse'
 # 指定した年月と曜日の文字列を文字列で表現
 def year_month_week_str(subject_date)
   # 年月を文字列
-  str_year_month = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
+  year_month_str = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
   # 曜日の文字列
   week_str = "\s日\s月\s火\s水\s木\s金\s土"
-  puts str_year_month.center(25) + "\n" + week_str.center(1)
+  puts year_month_str.center(25) + "\n" + week_str.center(1)
 end
 
-# 指定した年月の日数の取得
-def month_days(insert_date)
+# 指定した年月の日数データを週ごとに表示
+def weekly_date(insert_date)
   # 指定した年月の最終日を文字列で取得
   last_day_str = Date.new(insert_date.year, insert_date.month, -1)
   # last_day_strを使って最終日を取得
@@ -59,4 +59,4 @@ run_date = Date.new(year, month)
 # 年月の文字列の表示
 year_month_week_str(run_date)
 # 正規化した日数の表示
-month_days(run_date)
+weekly_date(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -3,31 +3,27 @@ require 'date'
 require 'optparse'
 
 # 指定した年月を文字列で表現
-def year_month_str(run_date)
-  # year_output = run_date.year.to_s
-  # month_output = run_date.month.to_s
-  output_string = run_date.month.to_s + "月" + "\s" + run_date.year.to_s
+def year_month_str(subject_date)
+  output_string = subject_date.month.to_s + "月" + "\s" + subject_date.year.to_s
 end
-p year_month_str
 # 曜日を文字列として表現
 def weeks_str
   "\s日\s月\s火\s水\s木\s金\s土"
 end
-p weeks_str
-# #指定した年月の日数の取得
-# def month_days(run_date)
-#   first_day = Date.new(@run_today.year, @run_today.month, 1)
-#   last_day = Date.new(run_date.year, run_date.month, -1)
+# # 指定した年月の日数の取得
+# def month_days(get_date)
+#   # first_day = Date.new(get_date.year, get_date.month, 1)
+#   last_day = Date.new(get_date.year, get_date.month, -1)
 
 #   output_string = ""
 #   output_string += year_month_str.center(21) + "\n"
 #   output_string += weeks_str + "\n"
   
-#   # #月頭の空白処理
+#   # 月頭の空白処理
 #   output_string += "".rjust(3) * first_day.wday
 
-#   # #取得した日数の月ごとの正規化
-#   # #日数の繰り返し
+#   # 取得した日数の月ごとの正規化
+#   # 日数の繰り返し
 #   (1..last_day).each do |day|
 #     if day.wday == 6
 #       output_string += day.day.to_s.rjust(3) + "\n"
@@ -60,5 +56,6 @@ else
   run_date = today
 end
 p run_date
+p year_month_str(run_date)
 # 正規化した日数の表示
-# puts month_days
+# puts month_days(run_date)

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+require 'date'
+require 'optparse'
+
+opt = OptionParser.new
+option = {}
+
+opt.on('-y [v]') {|v| option[:y] = v}
+opt.on('-m [v]') {|v| option[:m] = v}
+
+opt.parse!(ARGV)
+
+year_num = option[:y].to_i
+month_num = option[:m].to_i
+
+today = Date.today
+
+if year_num > 0 && month_num > 0
+  @run_today = Date.new(year_num, month_num)
+elsif year_num > 0
+  @run_today = Date.new(year = year_num, mon = today.month)
+elsif month_num > 0
+  @run_today = Date.new(year = today.year, mon = month_num)
+else
+  @run_today = Date.today
+end
+
+#指定した年月を取得
+def year_date
+  year_name = @run_today.year.to_s
+  month_name = @run_today.month.to_s
+  output_string = month_name + "月" + "\s" + year_name
+end
+
+#曜日の取得
+def weeks_name
+  "\s日\s月\s火\s水\s木\s金\s土"
+end
+
+#指定した年月の日数の取得
+def month_days
+  first_day = Date.new(@run_today.year, @run_today.month, 1)
+  last_day = Date.new(@run_today.year, @run_today.month, -1)
+
+  output_string = ""
+  output_string += year_date.center(21) + "\n"
+  output_string += weeks_name + "\n"
+  
+  # #月頭の空白処理
+  output_string += "".rjust(3) * first_day.wday
+
+  # #取得した日数の月ごとの正規化
+  # #日数の繰り返し
+  (first_day..last_day).each do |day|
+    if day.wday == 6
+      output_string += day.day.to_s.rjust(3) + "\n"
+    else
+      output_string += day.day.to_s.rjust(3)
+    end
+  end
+  output_string
+end
+
+# 正規化した日数の表示
+puts month_days


### PR DESCRIPTION
### 必須要件
- -mで月を、-yで年を指定できる
  - ただし、-yのみ指定して一年分のカレンダーを表示する機能の実装は不要
- 引数を指定しない場合は、今月・今年のカレンダーが表示される
- macに入っているcalコマンドと同じ見た目になっている
- 少なくとも1970年から2100年までは正しく表示される
### 歓迎要件
- 今日の日付の部分の色が反転する
- どのような引数が与えられようが、cal コマンドと同じ表示結果になる
### 感想
- ごく初歩的な課題かもしれないですが、自分にとってエンジニアとはどう考えるのかを知るよい機会になりました。
- 工数を大きく割いてしまったのは痛いですが、今回学んだ「何をしたいのか？」言語化することを意識して今後のプラクティスに取り組んで行きたいと思います。